### PR TITLE
Update http_request.rb

### DIFF
--- a/lib/api_callers/http_request.rb
+++ b/lib/api_callers/http_request.rb
@@ -23,7 +23,7 @@ module ApiCallers
     end
 
     def class_to_call
-      Kernel.const_get("Net::HTTP::#{@method.capitalize}")
+      Net::HTTP.const_get(@method.capitalize)
     end
 
   end


### PR DESCRIPTION
Fix for: wrong constant name Net::HTTP::Get
